### PR TITLE
add ur10e_robotiq to sharework_ws rosinstall 

### DIFF
--- a/installation_single_workspace.md
+++ b/installation_single_workspace.md
@@ -45,13 +45,6 @@ mkdir rosinstall
 wstool init src
 ```
 
-Now, add the repository to path:
-```
-echo "source /home/$USER/projects/ros_ws/devel/setup.bash" >> ~/.bashrc
-```
-To make the change effective, open and close the terminals or run _source ~/.bashrc_ manually.
-
-
 ### Third parties repositories
 ```
 wget https://raw.githubusercontent.com/JRL-CARI-CNR-UNIBS/installation/master/third_parties.rosinstall -P ./rosinstall
@@ -64,6 +57,12 @@ source devel/setup.bash
 ```
 
 The package _robotiq_3f_gripper_articulated_gazebo_plugins_ could fail during compilation, but it is not needed.
+
+Now, add the repository to path:
+```
+echo "source /home/$USER/projects/ros_ws/devel/setup.bash" >> ~/.bashrc
+```
+To make the change effective, open and close the terminals or run _source ~/.bashrc_ manually.
 
 
 ### control repositories

--- a/sharework_cembre.rosinstall
+++ b/sharework_cembre.rosinstall
@@ -5,6 +5,9 @@
     local-name: ur10e_robotiq_simplified
     uri: https://github.com/JRL-CARI-CNR-UNIBS/ur10e_robotiq_simplified.git
 - git:
+    local-name: ur10e_robotiq
+    uri: https://github.com/JRL-CARI-CNR-UNIBS/ur10e_robotiq.git
+- git:
     local-name: sharework_assembly
     uri: https://bitbucket.org/iras-ind/sharework_assembly.git
 - git:


### PR DESCRIPTION
1)aggìunta dì pacchetto per nuova versione cella sharework (da finire)
2)spostato 
"Now, add the repository to path:
```
echo "source /home/$USER/projects/ros_ws/devel/setup.bash" >> ~/.bashrc
```
To make the change effective, open and close the terminals or run _source ~/.bashrc_ manually."
a dopo la compilazione di third parties ws (devel non esiste prima)